### PR TITLE
Fix example indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm install -D @csstools/postcss-oklab-function
 export default {
     plugins: {
         tailwindcss: {},
-+        '@csstools/postcss-oklab-function': { 'preserve': true },
++       '@csstools/postcss-oklab-function': { 'preserve': true },
         autoprefixer: {},
     },
 }


### PR DESCRIPTION
A small type to keep the same indent for all PostCSS plugins in the example