### PR TITLE
Add support for Tailwind v4 CSS theme override

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ npm install @evilmartians/harmony
 
 Harmony can work as drop-in replacement for the Tailwind color palette:
 
+### Tailwind v4
+
+Simply import `@evilmartians/harmony/tailwind.css`:
+
+```css
+/* app.css, or anywhere within Tailwind-aware context */
+@import 'tailwindcss';
+@import "@evilmartians/harmony/tailwind.css";
+```
+
+### Tailwind v3
+
 ```js
 // tailwind.config.js
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "require": "./dist/tailwind/index.mjs",
       "types": "./dist/tailwind/index.d.ts"
     },
+    "./tailwind.css": "./dist/tailwind/index.css",
     "./base": {
       "import": "./dist/base/index.mjs",
       "require": "./dist/base/index.js",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -4,6 +4,7 @@ import { buildTailwindPalette } from "./targets/tailwind.ts";
 import { buildBasicPalette } from "./targets/base.ts";
 import { ExportTarget, PaletteWithFallback } from "./types.ts";
 import { buildCssVars } from "./targets/cssVariables.ts";
+import { buildTailwindv4Palette } from "./targets/tailwind-v4.ts";
 
 //
 // Config
@@ -18,6 +19,10 @@ const EXPORT_TARGETS = [
   {
     targetDir: "tailwind",
     target: buildTailwindPalette,
+  },
+  {
+    targetDir: "tailwind",
+    target: buildTailwindv4Palette,
   },
   {
     targetDir: "css",

--- a/scripts/targets/__snapshots__/tailwind-v4_test.ts.snap
+++ b/scripts/targets/__snapshots__/tailwind-v4_test.ts.snap
@@ -5,6 +5,9 @@ snapshot[`Tailwind v4 palette theme override 1`] = `
 @theme {
   --color-*: initial;
 
+  --color-white: #fff;
+  --color-black: #000;
+
   --color-red-100:oklch(0.966797 0.0171875 20);
   --color-red-500:oklch(0.742188 0.151562 20);
   

--- a/scripts/targets/__snapshots__/tailwind-v4_test.ts.snap
+++ b/scripts/targets/__snapshots__/tailwind-v4_test.ts.snap
@@ -1,0 +1,14 @@
+export const snapshot = {};
+
+snapshot[`Tailwind v4 palette theme override 1`] = `
+"
+@theme {
+  --color-*: initial;
+
+  --color-red-100:oklch(0.966797 0.0171875 20);
+  --color-red-500:oklch(0.742188 0.151562 20);
+  
+  --color-orange-100:oklch(0.966797 0.0171875 43.3333);
+  
+}"
+`;

--- a/scripts/targets/tailwind-v4.ts
+++ b/scripts/targets/tailwind-v4.ts
@@ -19,6 +19,9 @@ export const buildTailwindv4Palette: ExportTarget = async (
 @theme {
   --color-*: initial;
 
+  --color-white: #fff;
+  --color-black: #000;
+
   ${vars.join("\n  ")}
 }`;
 

--- a/scripts/targets/tailwind-v4.ts
+++ b/scripts/targets/tailwind-v4.ts
@@ -1,0 +1,26 @@
+import { path } from "../deps.ts";
+import type { ExportTarget } from "../types.ts";
+
+const css = String.raw;
+
+export const buildTailwindv4Palette: ExportTarget = async (
+  { palette, targetDir },
+) => {
+  const vars: string[] = [];
+
+  for (const [color, shades] of Object.entries(palette)) {
+    for (const [shade, value] of Object.entries(shades)) {
+      vars.push(`--color-${color}-${shade}:${value.oklch};`);
+    }
+    vars.push("");
+  }
+
+  const template = css`
+@theme {
+  --color-*: initial;
+
+  ${vars.join("\n  ")}
+}`;
+
+  await Deno.writeTextFile(path.join(targetDir, "index.css"), template);
+};

--- a/scripts/targets/tailwind-v4_test.ts
+++ b/scripts/targets/tailwind-v4_test.ts
@@ -1,0 +1,9 @@
+import { buildTailwindv4Palette } from "./tailwind-v4.ts";
+import { testExportTarget } from "./testUtils.ts";
+
+Deno.test("Tailwind v4 palette theme override", async (t) => {
+  await testExportTarget(t, buildTailwindv4Palette, [
+    "index.css",
+  ]);
+});
+


### PR DESCRIPTION
This PR adds a build target to `tailwind/index.css`, intended to support Tailwind V4 (currently in beta), which allows theme override using CSS syntax.

More information here: https://tailwindcss.com/docs/v4-beta#overriding-the-default-theme. 

> [!NOTE]
> Even though Tailwind V4 is in beta, I believe the syntax for theme override is unlikely to change, so this PR should be future proof. But if they do change I'm happy to follow-up.

----

Also, I noticed there is no pipeline for CHANGELOG generation and automatic publication. Happy to open a follow-up PR to set up [changesets](https://github.com/changesets/changesets) if you think that's helpful.

I have not bumped version or added to CHANGELOG.md either. Please let me know if you want me to do that in this PR as well.

Thanks!