### PR TITLE
Fix package.json to enable importmap pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   },
   "type": "module",
   "exports": {
+    ".": {
+      "types": "./dist/base/index.d.ts",
+      "require": "./dist/base/index.cjs",
+      "import": "./dist/base/index.js",
+      "default": "./dist/base/index.js"
+    },
     "./tailwind": {
       "types": "./dist/tailwind/index.d.ts",
       "require": "./dist/tailwind/index.cjs",


### PR DESCRIPTION
Hey there!

I love `harmony`. I love Rails 8! Rails 8 loves `importmap`. `importmap` does not love `@evilmartians/harmony`, because the package.json doesn't include a root 

But DHH and others at [this comment thread](https://github.com/rails/importmap-rails/issues/290) were helpful enough to point me to how to solve this problem. So, here's a pull request that fixes the issue, at least as far as Sonnet 3.7 is telling me (I'm not an `importmap` or `npm` expert).

Hope this helps! In the meantime, I will do `importmap pin @evilmartians/harmony/base`, but it'd be nice to fix this for everyone going forwards :-)

Warm Regards,

Daniel